### PR TITLE
Expose new endpoint with information about configured environments

### DIFF
--- a/src/main/java/no/digdir/simplifiedonboarding/AppController.java
+++ b/src/main/java/no/digdir/simplifiedonboarding/AppController.java
@@ -1,24 +1,14 @@
 package no.digdir.simplifiedonboarding;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.gateway.mvc.ProxyExchange;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api")
@@ -26,6 +16,9 @@ public class AppController {
 
     @Value("${frontend.uri}")
     private String frontendUri;
+
+    @Autowired
+    private MaskinportenConfig maskinportenConfig;
 
     @GetMapping("/user")
     public Map<String, Object> getAuthenticatedUser(@AuthenticationPrincipal OAuth2User principal) {
@@ -39,6 +32,23 @@ public class AppController {
     public void authenticate(HttpServletResponse httpServletResponse) {
         httpServletResponse.setHeader("Location", frontendUri + "/dashboard");
         httpServletResponse.setStatus(302);
+    }
+
+    @GetMapping("/config")
+    public Map<String, Map<String, String>> getConfiguration() throws Throwable {
+        HashMap<String, Map<String, String>> map = new HashMap<>();
+
+        //This should be rewritten to fetch issuer and token_endpoint from config.getAuthorizationServer() + "/.well-known/oauth-authorization-server". in accordance with https://datatracker.ietf.org/doc/html/rfc8414#section-3
+
+        for ( String e : maskinportenConfig.getEnvironments()) {
+            MaskinportenConfig.EnvironmentConfig config = maskinportenConfig.getConfigFor(e);
+            HashMap<String, String> envSpesifics = new HashMap<>();
+            envSpesifics.put("issuer", config.getAuthorizationServer()+ "/");
+            envSpesifics.put("token_endpoint", config.getAuthorizationServer()+ "/token");
+            envSpesifics.put("authorization_server", config.getAuthorizationServer());
+            map.put(e, envSpesifics);
+        }
+        return map;
     }
 
 

--- a/src/main/java/no/digdir/simplifiedonboarding/MaskinportenConfig.java
+++ b/src/main/java/no/digdir/simplifiedonboarding/MaskinportenConfig.java
@@ -32,7 +32,7 @@ public class MaskinportenConfig {
     public static class EnvironmentConfig {
 
         private String environment;
-        private String wellKnown;
+        private String authorizationServer;
         private String api;
 
         public String getEnvironment() {
@@ -43,12 +43,12 @@ public class MaskinportenConfig {
             this.environment = environment;
         }
 
-        public String getWellKnown() {
-            return wellKnown;
+        public String getAuthorizationServer() {
+            return authorizationServer;
         }
 
-        public void setWellKnown(String wellKnown) {
-            this.wellKnown = wellKnown;
+        public void setAuthorizationServer(String authorizationServer) {
+            this.authorizationServer = authorizationServer;
         }
 
         public String getApi() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,10 @@
 maskinporten-config:
   - environment: test
     api: ${MASKINPORTEN_API_URL}
-    well-known: "https://test.maskinporten.no/.well-known/oauth-authorization-server"
+    authorization-server: "https://test.maskinporten.no"
   - environment: ver2
     api: ${MASKINPORTEN_API_URL}
-    well-known: "https://ver2.maskinporten.no/.well-known/oauth-authorization-server"
+    authorization-server: "https://ver2.maskinporten.no"
 frontend:
   uri: ${SIMPLIFIED_ONBOARDING_FRONTEND_URL}
 spring:


### PR DESCRIPTION
If this is kept the implementation should fetch issues and token endpoint info from wellknown endpoint of authorization server This allows to populate the onboardingguide with correct urls for each client